### PR TITLE
fix: simplify favicons

### DIFF
--- a/head.html
+++ b/head.html
@@ -2,3 +2,6 @@
 <script src="/scripts/lib-franklin.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
+<link rel="icon" href="data:,">
+<link rel="apple-touch-icon" href="data:,">
+<link rel="manifest" href="/site.webmanifest">

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -83,17 +83,17 @@ async function loadEager(doc) {
 export function addFavIcon(
   href,
   rel = 'icon',
-  size = '',
-  type = 'image/png',
 ) {
   const link = document.createElement('link');
   link.rel = rel;
-  link.type = type;
   link.href = href;
-  if (size) {
-    link.sizes.add(size);
+
+  const existingLink = document.querySelector(`head link[rel="${rel}"]`);
+  if (existingLink) {
+    existingLink.parentElement.replaceChild(link, existingLink);
+  } else {
+    document.getElementsByTagName('head')[0].appendChild(link);
   }
-  document.getElementsByTagName('head')[0].appendChild(link);
 }
 
 /**
@@ -115,9 +115,6 @@ async function loadLazy(doc) {
 
   addFavIcon(`${window.hlx.codeBasePath}/styles/icons/favicon-32x32.png`);
   addFavIcon(`${window.hlx.codeBasePath}/styles/icons/favicon-180x180.png`, 'apple-touch-icon');
-  addFavIcon(`${window.hlx.codeBasePath}/styles/icons/favicon-180x180.png`, 'apple-touch-icon', '180x180');
-  addFavIcon(`${window.hlx.codeBasePath}/styles/icons/favicon-192x192.png`, 'apple-touch-icon', '192x192');
-  addFavIcon(`${window.hlx.codeBasePath}/styles/icons/favicon-270x270.png`, 'apple-touch-icon', '270x270');
   createMetadata('msapplication-TileImage', `${window.hlx.codeBasePath}/styles/icons/favicon-270x270.png`);
 
   sampleRUM('lazy');

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -1,0 +1,12 @@
+{
+    "name": "Mammotome",
+    "short_name": "Mammotome",
+    "icons": [
+        {
+            "src": "/styles/icons/favicon-192x192.png",
+            "sizes": "192x192",
+            "type": "image/png"
+        }
+    ],
+    "display": "standalone"
+}


### PR DESCRIPTION
reducing amount of icon definitions and re-introduction data placeholder so browsers still see the icon even if loaded lazily.

also introducing android site manifest

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/en/
- After: https://simplify-favicons--mammotome--hlxsites.hlx.page/en/
