### PR TITLE
fix: active nav highlighting

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -569,6 +569,9 @@ header nav.nav-mobile .nav-overflow {
     background-color: var(--mt-header-menu-item-selected-color);
   }
 
+  header nav li .active {
+    background-color: var(--mt-header-menu-item-selected-color);
+  }
 
   header nav .nav-sections .nav-button a {
     border: 1px solid var(--mt-global-color-base-primary);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -3,6 +3,7 @@ import {
   decorateIcons,
   translate,
   getProducts,
+  setActiveLink,
 } from '../../scripts/lib-franklin.js';
 
 // media query match that indicates mobile/tablet width
@@ -412,6 +413,8 @@ export default async function decorate(block) {
       navSections.querySelector('ul').prepend(createMobileMenuControlsBlock());
       navSections.querySelector('ul').append(createOverflowDropdown(navSections));
       decorateLanguageNav(navSections);
+      const multiLevelNav = navSections.querySelectorAll('li.nav-multilevel > ul > li > ul > li a');
+      setActiveLink(multiLevelNav);
     }
 
     // hamburger for mobile

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -414,7 +414,7 @@ export default async function decorate(block) {
       navSections.querySelector('ul').append(createOverflowDropdown(navSections));
       decorateLanguageNav(navSections);
       const multiLevelNav = navSections.querySelectorAll('li.nav-multilevel > ul > li > ul > li a');
-      setActiveLink(multiLevelNav);
+      setActiveLink(multiLevelNav, 'active');
     }
 
     // hamburger for mobile

--- a/blocks/tab-navigation/tab-navigation.js
+++ b/blocks/tab-navigation/tab-navigation.js
@@ -2,5 +2,5 @@ import { setActiveLink } from '../../scripts/lib-franklin.js';
 
 export default function decorate(block) {
   const links = block.querySelectorAll('a');
-  setActiveLink(links);
+  setActiveLink(links, 'active');
 }

--- a/blocks/tab-navigation/tab-navigation.js
+++ b/blocks/tab-navigation/tab-navigation.js
@@ -1,13 +1,6 @@
-import { getMetadata } from '../../scripts/lib-franklin.js';
+import { setActiveLink } from '../../scripts/lib-franklin.js';
 
 export default function decorate(block) {
   const links = block.querySelectorAll('a');
-  if (!links.length) return;
-  const actualPage = getMetadata('og:url').split('/').slice(-1)[0].toLowerCase();
-  links.forEach((a) => {
-    const href = a.getAttribute('href').toLowerCase();
-    if (href.includes(actualPage)) {
-      a.classList.add('active');
-    }
-  });
+  setActiveLink(links);
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -696,14 +696,15 @@ export function decorateTemplateAndTheme() {
 /**
  * Set Link class to active when on the same page
  * @param links {NodeListOf<Element>} Array of links to check
+ * @param className {string} Class to add to active link
  */
-export function setActiveLink(links) {
+export function setActiveLink(links, className) {
   if (!links.length) return;
   const actualPage = getMetadata('og:url').split('/').slice(-1)[0].toLowerCase();
   links.forEach((a) => {
     const href = a.getAttribute('href') ? a.getAttribute('href').toLowerCase() : '';
     if (href.includes(actualPage)) {
-      a.classList.add('active');
+      a.classList.add(className);
     }
   });
 }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -699,10 +699,10 @@ export function decorateTemplateAndTheme() {
  * @param className {string} Class to add to active link
  */
 export function setActiveLink(links, className) {
-  if (!links.length) return;
+  if (!links || links.length === 0) return;
   const actualPage = getMetadata('og:url').split('/').slice(-1)[0].toLowerCase();
   links.forEach((a) => {
-    const href = a.getAttribute('href') ? a.getAttribute('href').toLowerCase() : '';
+    const href = (a.getAttribute('href') || '').toLowerCase();
     if (href.includes(actualPage)) {
       a.classList.add(className);
     }

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -694,6 +694,21 @@ export function decorateTemplateAndTheme() {
 }
 
 /**
+ * Set Link class to active when on the same page
+ * @param links {NodeListOf<Element>} Array of links to check
+ */
+export function setActiveLink(links) {
+  if (!links.length) return;
+  const actualPage = getMetadata('og:url').split('/').slice(-1)[0].toLowerCase();
+  links.forEach((a) => {
+    const href = a.getAttribute('href') ? a.getAttribute('href').toLowerCase() : '';
+    if (href.includes(actualPage)) {
+      a.classList.add('active');
+    }
+  });
+}
+
+/**
  * Decorates paragraphs containing a single link as buttons.
  * @param {Element} element container element
  */


### PR DESCRIPTION
Add active link highlighting for MultiNav (typical product pages) and refactor tab-navigation.js → move setActiveLink function to franklin lib

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #147 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/en/

After: 
- https://147-highlight-active-page-in-top-nav--mammotome--hlxsites.hlx.page/en/
- https://147-highlight-active-page-in-top-nav--mammotome--hlxsites.hlx.page/en/patient-resources/understanding-biopsy-results
