### PR TITLE
fix: overlap with hero block + added 'narrow' style

### DIFF
--- a/blocks/collapsible/collapsible.css
+++ b/blocks/collapsible/collapsible.css
@@ -80,3 +80,16 @@
     margin-block-end: 1em;
     text-align: left;
 }
+
+.section.arc-after-section.collapsible-container {
+    margin-top: 0;
+}
+
+.collapsible-wrapper {
+  display: flex;
+  justify-content: center;
+}
+
+.collapsible.narrow {
+    max-width: 610px;
+}


### PR DESCRIPTION
Collapsible moves into hero

Fix #194

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/en/patient-resources/faq-about-the-devices
- After: https://194-collpsible-moves-inot-hero--mammotome--hlxsites.hlx.page/en/patient-resources/faq-about-the-devices


- [x] collapsible should not overlap with hero
- [x] 'narrow' style should have effect