### PR TITLE
fix for hero hides headlines

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -20,6 +20,7 @@ main .columns h5,
 main .columns h6,
 main .columns p {
  text-align: left;
+  position: relative;
 }
 
 main .columns h4 {


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #196 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/en/portfolios/stereotactic
- After: https://196-hero-hides-parts-of-h2--mammotome--hlxsites.hlx.page/en/portfolios/stereotactic
