### PR TITLE
fix: hide overflow-x for enclosing ul

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -208,10 +208,6 @@ header nav:not(.nav-mobile) .nav-sections > ul > li:nth-last-child(2) {
   display: none;
 }
 
-header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul {
-  overflow-x: hidden;
-}
-
 header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul > li {
   text-transform: uppercase;
   text-align: center;
@@ -344,6 +340,10 @@ header nav .nav-sections > ul > li[aria-expanded="true"] > ul {
   display: flex;
   flex-direction: column;
   z-index: 200;
+}
+
+header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul {
+  overflow-x: hidden;
 }
 
 header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul > li > ul {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -208,6 +208,10 @@ header nav:not(.nav-mobile) .nav-sections > ul > li:nth-last-child(2) {
   display: none;
 }
 
+header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul {
+  overflow-x: hidden;
+}
+
 header nav .nav-sections > ul > li.nav-multilevel[aria-expanded="true"] > ul > li {
   text-transform: uppercase;
   text-align: center;


### PR DESCRIPTION
Please make sure to configure your mobile browser appropriately before testing (e.g. Safari should use the desktop browser).

Fix #234 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/
- After: https://234-fix--mammotome--hlxsites.hlx.page/us/en/

