### PR TITLE
317 - force wrapping the content of text-only columns in a paragraph

### DIFF
--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,3 +1,20 @@
+/**
+ * Sometimes in columns containing only text,
+ * the text is not wrapped by a paragraph.
+ * This breaks the styling and makes it difficult to identify
+ * text only columns. This methods fixes it by forcing wrapping
+ * the text in a paragraph.
+ * @param {HTMLElement} col
+ */
+function decorateOnlyTextColumn(col) {
+  if (col.firstChild && col.firstChild.nodeType === Node.TEXT_NODE
+     && !col.firstElementChild) {
+    const paragraph = document.createElement('p');
+    paragraph.appendChild(col.firstChild);
+    col.appendChild(paragraph);
+  }
+}
+
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
   block.classList.add(`columns-${cols.length}-cols`);
@@ -5,6 +22,7 @@ export default function decorate(block) {
   // setup image columns
   [...block.children].forEach((row) => {
     [...row.children].forEach((col, index) => {
+      decorateOnlyTextColumn(col);
       const pic = col.querySelector('picture');
       const text = col.querySelector('p');
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #317 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/about-us/
- After: https://317-enforce-paragraph-in-text-only-columns--mammotome--hlxsites.hlx.page/us/en/about-us/
