### PR TITLE
Fix the pdf download links in the product support.

### DIFF
--- a/blocks/product-support/product-support.js
+++ b/blocks/product-support/product-support.js
@@ -108,7 +108,7 @@ export default async function decorate(block) {
       createDomStructure(assets.map((asset) => (
         {
           type: 'div',
-          classes: ['link'],
+          classes: ['link', 'button-container'],
           children: [
             {
               type: 'a',

--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -837,7 +837,7 @@ export function decorateButtons(element) {
       if (a.href !== a.textContent && !a.querySelector('img')) {
         const parent = a.parentElement;
         const grandparent = parent.parentElement;
-        if (a.href.includes('.pdf') && parent.tagName === 'div' && parent.classList.contains('button-container')) {
+        if (a.href.includes('.pdf') && parent.tagName.toLocaleLowerCase() === 'div' && parent.classList.contains('button-container')) {
           const icon = document.createElement('i');
           icon.classList.add('link-icon');
           icon.innerHTML = PDF_ICON;


### PR DESCRIPTION
The detection for adding icons to pdf download links assumes that tagNames are lowercase - which must not be the case. Furthermore, in the case of at least the product-support, the links where not wrapped in a `button-container`div.

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/product-support/mammotome-revolve-support
- After: https://fix-pdf-button--mammotome--hlxsites.hlx.page/us/en/product-support/mammotome-revolve-support
