### PR TITLE
Fix product reference target when in nested subpage

### DIFF
--- a/blocks/product-reference/product-reference.js
+++ b/blocks/product-reference/product-reference.js
@@ -2,7 +2,7 @@ import {
   createDomStructure, decorateBlockImgs, getInfo, getProduct, translate,
 } from '../../scripts/lib-franklin.js';
 
-async function createButtons(productCode) {
+async function createButtons(country, language, productCode) {
   return [
     [
       await translate('productReferenceInformationURL', '../contact/'),
@@ -15,7 +15,7 @@ async function createButtons(productCode) {
       await translate('productReferenceSupport', 'Product Support'),
     ],
     [
-      `${await translate('productReferenceSupportURL', '../product-support')}/${productCode}`,
+      `/${country}/${language}/${await translate('productReferenceSupportURL', 'product-support')}/${productCode}`,
       ['secondary'],
       await translate('productReferenceDocuments', 'Product Documents'),
     ],
@@ -39,7 +39,7 @@ export default async function decorate(block) {
     return;
   }
 
-  const buttons = await createButtons(product.Page);
+  const buttons = await createButtons(country, language, product.Page);
 
   const imgStructure = [
     {


### PR DESCRIPTION
When a `product-reference` is used in a nested sub-path like e.g.: `/it/it/products/mammotome-revolve/mammotome-revolve-u-s` it ends up reference the wrong url because it only goes one level up. In the example, it ends-up being `/it/it/products/product-support/mammotome-revolve`. Instead, it should always go directly under `/<country>/<lang>/product-support`

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/it/it/products/mammotome-revolve/mammotome-revolve-u-s
- After: https://fix-product-reference--mammotome--hlxsites.hlx.page/it/it/products/mammotome-revolve/mammotome-revolve-u-s
