### PR TITLE
fix: ifus align should only target headers below ifus block

### DIFF
--- a/blocks/ifus/ifus.css
+++ b/blocks/ifus/ifus.css
@@ -25,7 +25,7 @@
     }
 }
 
-.ifus h2, h3, h4 {
+.ifus h2, .ifus h3, .ifus h4 {
     font-weight: var(--mt-font-weight-bold);
     text-align: left;
 }


### PR DESCRIPTION


Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/ifu-index
- After: https://ifus-align--mammotome--hlxsites.hlx.page/us/en/ifu-index
