### PR TITLE
fix: hide pdf link

### DIFF
--- a/blocks/pdf-viewer/pdf-viewer.css
+++ b/blocks/pdf-viewer/pdf-viewer.css
@@ -1,4 +1,4 @@
-.pdf-viewer.block > div > div.button-container > a {
+.pdf-viewer.block > div > div > a {
     display: none;
 }
 


### PR DESCRIPTION
PDF document link is erroneously shown for PDF viewer

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/products/catalog
- After: https://fix-hide-pdf-viewer-link--mammotome--hlxsites.hlx.page/us/en/products/catalog
