### PR TITLE
fix: decorateButtons tries to detect pdfs before it adds button container

### DIFF
--- a/scripts/lib-franklin.js
+++ b/scripts/lib-franklin.js
@@ -905,16 +905,6 @@ export function decorateButtons(element) {
       if (a.href !== a.textContent && !a.querySelector('img')) {
         const parent = a.parentElement;
         const grandparent = parent.parentElement;
-        if (a.href.includes('.pdf') && parent.tagName.toLocaleLowerCase() === 'div' && parent.classList.contains('button-container')) {
-          const icon = document.createElement('i');
-          icon.classList.add('link-icon');
-          icon.innerHTML = PDF_ICON;
-          const spanText = document.createElement('span');
-          spanText.innerHTML = a.innerHTML;
-          a.innerHTML = '';
-          a.appendChild(icon);
-          a.appendChild(spanText);
-        }
         const isSingleChild = (el, tagName) => el.childNodes.length === 1 && el.tagName === tagName;
         const addClassAndContainer = (el, className, containerClass) => {
           a.className = className;
@@ -927,6 +917,16 @@ export function decorateButtons(element) {
           addClassAndContainer(grandparent, 'button primary', 'button-container');
         } else if (isSingleChild(parent, 'EM') && isSingleChild(grandparent, 'P')) {
           addClassAndContainer(grandparent, 'button secondary', 'button-container');
+        }
+        if (a.href.includes('.pdf') && parent.tagName.toLocaleLowerCase() === 'div' && parent.classList.contains('button-container')) {
+          const icon = document.createElement('i');
+          icon.classList.add('link-icon');
+          icon.innerHTML = PDF_ICON;
+          const spanText = document.createElement('span');
+          spanText.innerHTML = a.innerHTML;
+          a.innerHTML = '';
+          a.appendChild(icon);
+          a.appendChild(spanText);
         }
       }
     }


### PR DESCRIPTION
That is a problem because it wants a button-container class on the parent of the pdf link. In the corner case where it adds a button-container class to the parent, it does that after it looked whether the parent has that class. Doing it the other way around, it works.

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/healthcare-professionals/clinical-evidence
- After: https://fix-decorate-buttons--mammotome--hlxsites.hlx.page/us/en/healthcare-professionals/clinical-evidence