### PR TITLE
fix: IFU result buttons text uppercase

### DIFF
--- a/blocks/ifus/ifus.css
+++ b/blocks/ifus/ifus.css
@@ -73,6 +73,7 @@
     display: block;
     white-space: nowrap;
     text-align: center;
+    text-transform: uppercase;
     width: 100%;
 }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #310 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/ifu-index
- After: https://310-eifu-buttons--mammotome--hlxsites.hlx.page/us/en/ifu-index
