### PR TITLE
fix: subpixel issue in safari creates line between arc and section.

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1007,6 +1007,8 @@ main .section.our-history .year.highlight .icon-calendar {
   max-width: 110%;
   fill: var(--mt-background-color-primary);
   background-color: transparent;
+  position: relative;
+  top: -1px;
 }
 
 /* Position preceding content */


### PR DESCRIPTION
On Safari (both on the desktop as well as on mobil) there is a sub pixel issue that can cause the arc at the bottom of the page to not align completely with the section above it - causing a sub pixel gap where the background shines through. That looks like an arbitrary line e.g.:

![Bildschirm_foto 2023-06-28 um 16 51 00](https://github.com/hlxsites/mammotome/assets/410610/f2703e42-1cfd-4e0a-8335-c0d5c8fc97ff)

The reason is that we use percentage for the margins and if those end-up as not a whole number that sub-pixel will be where the arc box starts - having a small visual gap where the background comes through. 

As there is no good way to round those margins in the css (at least none that I could fine), the simplest solution seems to be to just position the arc svg relative and pull it up one negative pixel. 


Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/
- After: https://subpixel--mammotome--hlxsites.hlx.page/us/en/
