### PR TITLE
fix: also support parameters in form link

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -378,7 +378,7 @@ async function createForm(formURL) {
 }
 
 export default async function decorate(block) {
-  const formLink = block.querySelector('a[href$=".json"]');
+  const formLink = block.querySelector('a[href*=".json"]');
   if (formLink) {
     const form = await createForm(formLink.href);
     formLink.replaceWith(form);


### PR DESCRIPTION
Currently the forms block doesn't match form URLs ending in anything else than ".json", e.g. ".json?sheet=de" - this is needed for multi-language support

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/de/de/kontakt
- After: https://forms-support-language-sheets--mammotome--hlxsites.hlx.page/de/de/kontakt
