### PR TITLE
fix: re-add language support (overwritten by other p)

### DIFF
--- a/blocks/form/form.js
+++ b/blocks/form/form.js
@@ -352,8 +352,8 @@ async function fetchForm(pathname) {
 }
 
 async function createForm(formURL) {
-  const { pathname } = new URL(formURL);
-  const data = await fetchForm(pathname);
+  const { pathname, search } = new URL(formURL);
+  const data = await fetchForm(`${pathname}${search}`);
   const form = document.createElement('form');
   data.forEach((fd) => {
     const el = renderField(fd);


### PR DESCRIPTION
Re-add what another PR overwrote by mistake.

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/de/de/kontakt
- After: https://forms-support-language-sheets-2--mammotome--hlxsites.hlx.page/de/de/kontakt
