### PR TITLE
fix: product support reference url

### DIFF
--- a/blocks/product-list/product-list.js
+++ b/blocks/product-list/product-list.js
@@ -1,8 +1,14 @@
 import {
-  createDomStructure, decorateBlockImgs, decorateSupScript, getInfo, getProducts,
+  createDomStructure,
+  decorateBlockImgs,
+  decorateSupScript,
+  getConfigValue,
+  getInfo,
+  getProducts,
+  toCamelCase,
 } from '../../scripts/lib-franklin.js';
 
-function decorateProduct(product) {
+function decorateProduct(base, product) {
   const children = [
     { type: 'h4', children: decorateSupScript(product.Name) },
   ];
@@ -18,7 +24,7 @@ function decorateProduct(product) {
   return {
     type: 'a',
     classes: ['product'],
-    attributes: { href: `product-support/${product.Page}` },
+    attributes: { href: `${base}/${product.Page}` },
     children,
   };
 }
@@ -26,12 +32,13 @@ function decorateProduct(product) {
 export default async function decorate(block) {
   const { country, language } = getInfo();
   const products = await getProducts(country, language);
+  const base = `/${country}/${language}/${await getConfigValue(`${toCamelCase(`product Reference Support Url ${country}/${language}`)}`, 'product-support')}`;
 
   createDomStructure([
     {
       type: 'div',
       classes: ['product-list'],
-      children: products.map(decorateProduct),
+      children: products.map((product) => decorateProduct(base, product)),
     }], block);
 
   decorateBlockImgs(block);

--- a/blocks/product-reference/product-reference.js
+++ b/blocks/product-reference/product-reference.js
@@ -15,7 +15,7 @@ async function createButtons(country, language, productCode) {
       await translate('productReferenceSupport', 'Product Support'),
     ],
     [
-      `/${country}/${language}/${await translate('productReferenceSupportUrl', 'product-support')}/${productCode}`,
+      `${await translate('productReferenceSupportUrl', '../product-support')}/${productCode}`,
       ['secondary'],
       await translate('productReferenceDocuments', 'Product Documents'),
     ],

--- a/blocks/product-reference/product-reference.js
+++ b/blocks/product-reference/product-reference.js
@@ -1,21 +1,27 @@
 import {
-  createDomStructure, decorateBlockImgs, getInfo, getProduct, translate,
+  createDomStructure,
+  decorateBlockImgs,
+  getConfigValue,
+  getInfo,
+  getProduct,
+  toCamelCase,
+  translate,
 } from '../../scripts/lib-franklin.js';
 
 async function createButtons(country, language, productCode) {
   return [
     [
-      await translate('productReferenceInformationUrl', '../contact/'),
+      `/${country}/${language}/${await getConfigValue(`${toCamelCase(`product Reference Information Url ${country}/${language}`)}`, 'contact/')}`,
       ['primary'],
       await translate('productReferenceInformation', 'Request Information'),
     ],
     [
-      await translate('productReferenceSupportUrl', '../product-support'),
+      `/${country}/${language}/${await getConfigValue(`${toCamelCase(`product Reference Support Url ${country}/${language}`)}`, 'product-support')}`,
       ['secondary'],
       await translate('productReferenceSupport', 'Product Support'),
     ],
     [
-      `${await translate('productReferenceSupportUrl', '../product-support')}/${productCode}`,
+      `/${country}/${language}/${await getConfigValue(`${toCamelCase(`product Reference Support Url ${country}/${language}`)}`, 'product-support')}/${productCode}`,
       ['secondary'],
       await translate('productReferenceDocuments', 'Product Documents'),
     ],


### PR DESCRIPTION
The actual issue in #427 was that there was no translation placeholder in place for the contact and product-support urls in the us/en version. After adding those, it worked - however, there is a bug in the product reference block that in one case is prepending the country and language to that url which makes it point to an invalid url if the product-support url is set via the placeholders. This PR fixes that.

Fix #427 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/products/breast-biopsy-markers/
- After: https://427-product-support-ref--mammotome--hlxsites.hlx.page/us/en/products/breast-biopsy-markers/
