### PR TITLE
Columns: Margin 8% not needed everywhere

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -265,7 +265,7 @@ main .columns.image-color-light-blue > div > .columns-img-col::before {
     gap: 0;
   }
 
-  main .columns > div:not(:first-child) {
+  main .columns[class*="image-color-"] > div:not(:first-child) {
     margin-top: 8%;
   }
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #422 

Test URLs:
URLs without the margin:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/healthcare-professionals/clinical-evidence
- After: https://422-columns-margin--mammotome--hlxsites.hlx.page/us/en/healthcare-professionals/clinical-evidence

URLs that needed the margin:
- Before:  https://main--mammotome--hlxsites.hlx.page/us/en/portfolios/magnetic-lesion-localization
- After: https://422-columns-margin--mammotome--hlxsites.hlx.page/us/en/portfolios/magnetic-lesion-localization

