### PR TITLE
fix: optimize background image for breakpoints

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -27,6 +27,7 @@ const LCP_BLOCKS = ['hero', 'product-reference', 'product-support']; // add your
 window.hlx.RUM_GENERATION = 'mammotome'; // add your RUM generation information here
 
 // Define the custom audiences mapping for experimentation
+// noinspection JSUnusedGlobalSymbols
 const EXPERIMENTATION_CONFIG = {
   audiences: {
     device: {
@@ -222,8 +223,8 @@ export async function decorateMain(main) {
   decorateSupScriptInTextBelow(main);
 
   if (main.querySelector('.section.our-history')) {
-    decorateHistorySection(main);
-    observeHistorySection(main);
+    await decorateHistorySection(main);
+    await observeHistorySection(main);
   }
 }
 
@@ -309,7 +310,7 @@ async function loadLazy(doc) {
   }
 
   // Mark customer as having viewed the page once
-  localStorage.setItem('franklin-visitor-returning', true);
+  localStorage.setItem('franklin-visitor-returning', Boolean(true).toString());
 
   document.dispatchEvent(new Event('franklin.loadLazy_completed'));
 }


### PR DESCRIPTION
Fix background image optimization: use resize observer to select correct breakpoints irrespective of Device Pixel Ratio (DPR) as before.

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/
- After: 
  - https://blurry-background-image--mammotome--hlxsites.hlx.page/us/en/
  - https://blurry-background-image--mammotome--hlxsites.hlx.page/dj-test/en/
