### PR TITLE
575 fix: Update prev-next.js using HTML instead of Text

### DIFF
--- a/blocks/prev-next/prev-next.js
+++ b/blocks/prev-next/prev-next.js
@@ -10,11 +10,11 @@ const HTML_ARROW_NEXT = '<svg fill="rgba(129,51,151,1)" width="30px" height="30p
 
 export default async function decorate(block) {
   const moveHeaderLinkDiv = (el) => {
-    const text = el.innerText;
+    const text = el.innerHTML;
     const newDiv = document.createElement('div');
     newDiv.classList.add('prev-next-header-link');
-    newDiv.innerText = text;
-    el.innerText = '';
+    newDiv.innerHTML = text;
+    el.innerHTML = '';
     el.insertAdjacentElement('afterbegin', newDiv);
   };
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #575 

Test URLs:
- Before: https://main--mammotome--hlxsites.hlx.page/us/en/
- After: https://575-bug-text-prev-next--mammotome--hlxsites.hlx.page/us/en/
- After: https://main--mammotome--hlxsites.hlx.page/us/en/about-us/news-media-category/mammotome-launches-lumimark-press-release
